### PR TITLE
Trim output by piping to a filtering function

### DIFF
--- a/shellcheck-repl.bash
+++ b/shellcheck-repl.bash
@@ -19,6 +19,10 @@ sc_repl_verify_or_unbind() {
     if [[ -n "${SHELLCHECK_REPL_EXCLUDE}" ]]; then
         opts+=("--exclude=${SHELLCHECK_REPL_EXCLUDE}")
     fi
+    # Option -C/--color requires ShellCheck (>= 0.4.2)
+    if version_gt "${SHELLCHECK_VERSION}" 0.4.1; then
+        opts+=("--color=always")
+    fi
     # Option -S/--severity requires ShellCheck (>= 0.6.0)
     if version_gt "${SHELLCHECK_VERSION_X_Y}" 0.5; then
         opts+=("--severity=\"${SHELLCHECK_REPL_VERIFY_LEVEL:=info}\"")

--- a/shellcheck-repl.bash
+++ b/shellcheck-repl.bash
@@ -27,10 +27,17 @@ sc_repl_verify_or_unbind() {
     if version_gt "${SHELLCHECK_VERSION_X_Y}" 0.5; then
         opts+=("--severity=\"${SHELLCHECK_REPL_VERIFY_LEVEL:=info}\"")
     fi
-    ## Execute shell command: sc_repl_verify_bind_accept
-    ## Triggered by key sequence: Ctrl-x Ctrl-b 2
-    shellcheck "${opts[@]}" <(printf '%s\n' "$READLINE_LINE") ||
+    # Filter the output of shellcheck by removing filename
+    case ${SHELLCHECK_REPL_INFO,,} in
+        gcc|short) shellcheck "${opts[@]}" --format=gcc <(printf '%s\n' "$READLINE_LINE") | cut -d : -f 4- ;;
+        full|wiki) shellcheck "${opts[@]}" <(printf '%s\n' "$READLINE_LINE") | tail -n +2 ;;
+        *) shellcheck "${opts[@]}" <(printf '%s\n' "$READLINE_LINE") | sed -n '1,2b; /^$/q; p' ;;
+    esac
+    if [[ "$PIPESTATUS" != 0 ]]; then
+        ## Execute shell command: sc_repl_verify_bind_accept
+        ## Triggered by key sequence: Ctrl-x Ctrl-b 2
         bind -x '"\C-x\C-b2": sc_repl_verify_bind_accept'
+    fi
 }
 
 sc_repl_verify_bind_accept() {

--- a/shellcheck-repl.bash
+++ b/shellcheck-repl.bash
@@ -31,9 +31,10 @@ sc_repl_verify_or_unbind() {
     case ${SHELLCHECK_REPL_INFO,,} in
         gcc|short) shellcheck "${opts[@]}" --format=gcc <(printf '%s\n' "$READLINE_LINE") | cut -d : -f 4- ;;
         full|wiki) shellcheck "${opts[@]}" <(printf '%s\n' "$READLINE_LINE") | tail -n +2 ;;
+        none) shellcheck "${opts[@]}" <(printf '%s\n' "$READLINE_LINE") ;;
         *) shellcheck "${opts[@]}" <(printf '%s\n' "$READLINE_LINE") | sed -n '1,2b; /^$/q; p' ;;
     esac
-    if [[ "$PIPESTATUS" != 0 ]]; then
+    if [[ "${PIPESTATUS[1]}" != 0 ]]; then
         ## Execute shell command: sc_repl_verify_bind_accept
         ## Triggered by key sequence: Ctrl-x Ctrl-b 2
         bind -x '"\C-x\C-b2": sc_repl_verify_bind_accept'


### PR DESCRIPTION
I also add a check for `--color=always` support (since 0.4.2).

Feel free to toy around to your liking. This will remove the `In /dev/fd/XX line 1` line from the output.  To do this, we use `PIPESTATUS` to get shellcheck's exit code.